### PR TITLE
Naming conversion for different AVRs MCU's

### DIFF
--- a/bootutilsconsts.inc
+++ b/bootutilsconsts.inc
@@ -1,0 +1,29 @@
+const
+{$if defined(FPC_MCU_ATmega168) or defined(FPC_MCU_ATmega168A) or defined(FPC_MCU_ATmega168P) or defined(FPC_MCU_ATmega168PA) or defined(FPC_MCU_ATmega168PB)}
+{$elseif defined(FPC_MCU_ATmega328) or defined(FPC_MCU_ATmega328P) or defined(FPC_MCU_ATmega328PB)}
+
+  xEEPE = EEPE;
+  xEEMPE = EEMPE;
+
+  {$define xMCUSR := MCUSR}
+  {$define xWDTCSR := WDTCSR}
+
+var
+  xSPMCSR : byte absolute $00+$57;
+
+{$elseif defined (FPC_MCU_ATmega644) or defined (FPC_MCU_ATmega644P) or defined (FPC_MCU_ATmega644PA) or defined (FPC_MCU_ATmega644PB)}
+{$elseif defined(FPC_MCU_ATtiny84) or defined(FPC_MCU_ATtiny84A)}
+{$elseif defined(FPC_MCU_ATmega1280)}
+{$elseif defined(FPC_MCU_ATmega88) or defined(FPC_MCU_ATmega88A) or defined(FPC_MCU_ATmega88P) or defined(FPC_MCU_ATmega88PA)  or defined(FPC_MCU_ATmega88PB)}
+{$elseif defined(FPC_MCU_ATmega8) or defined(FPC_MCU_ATmega8A)}
+
+  xEEPE = EEWE;
+  xEEMPE = EEMWE;
+
+  {$define xMCUSR := MCUCR}
+  {$define xWDTCSR := WDTCR}
+
+var
+  xSPMCSR : byte absolute $00+$57;
+
+{$endif}

--- a/uart.pas
+++ b/uart.pas
@@ -13,37 +13,39 @@ function uart_receive: byte;
 
 implementation
 
+{$I uartconsts.inc}
+
 procedure uart_init(const UBRR: word);
 begin
-  UBRR0H := UBRR shr 8;
-  UBRR0L := byte(UBRR);
+  xUBRR0H := UBRR shr 8;
+  xUBRR0L := byte(UBRR);
 
   // Set U2X bit
-  UCSR0A := UCSR0A or (1 shl U2X0);
+  xUCSR0A := xUCSR0A or (1 shl xU2X0);
 
   // Enable receiver and transmitter
-  UCSR0B := (1 shl RXEN0) or (1 shl TXEN0);
+  xUCSR0B := (1 shl xRXEN0) or (1 shl xTXEN0);
 
   // Set frame format: 8data, 1stop bit, no parity
-  UCSR0C := (3 shl UCSZ0);
+  xUCSR0C := (1 shl xURSEL0) or (3 shl xUCSZ0);
 end;
 
 procedure uart_transmit(const data: byte);
 begin
   // Wait for empty transmit buffer
-  while ((UCSR0A and (1 shl UDRE0)) = 0) do;
+  while ((xUCSR0A and (1 shl xUDRE0)) = 0) do;
 
   // Put data into buffer, sends the data
-  UDR0 := data;
+  xUDR0 := data;
 end;
 
 function uart_receive: byte;
 begin
   // Wait for data to be received
-  while ((UCSR0A and (1 shl RXC0)) = 0) do;
+  while ((xUCSR0A and (1 shl xRXC0)) = 0) do;
 
   // Get and return received data from buffer
-  result := UDR0;
+  result := xUDR0;
 end;
 
 end.

--- a/uartconsts.inc
+++ b/uartconsts.inc
@@ -1,0 +1,43 @@
+const
+{$if defined(FPC_MCU_ATmega168) or defined(FPC_MCU_ATmega168A) or defined(FPC_MCU_ATmega168P) or defined(FPC_MCU_ATmega168PA) or defined(FPC_MCU_ATmega168PB)}
+{$elseif defined(FPC_MCU_ATmega328) or defined(FPC_MCU_ATmega328P) or defined(FPC_MCU_ATmega328PB)}
+
+  xU2X0   = U2X0;
+  xRXEN0  = RXEN0;
+  xTXEN0  = TXEN0;
+  xRXC0   = RXC0;
+  xUDRE0  = UDRE0;
+  xUCSZ0  = UCSZ0;
+  xURSEL0 = 0;
+
+  {$define xUBRR0H := UBRR0H}
+  {$define xUBRR0L := UBRR0L}
+  {$define xUCSR0A := UCSR0A}
+  {$define xUCSR0B := UCSR0B}
+  {$define xUCSR0C := UCSR0C}
+  {$define xUDR0   := UDR0}
+
+{$elseif defined (FPC_MCU_ATmega644) or defined (FPC_MCU_ATmega644P) or defined (FPC_MCU_ATmega644PA) or defined (FPC_MCU_ATmega644PB)}
+{$elseif defined(FPC_MCU_ATtiny84) or defined(FPC_MCU_ATtiny84A)}
+{$elseif defined(FPC_MCU_ATmega1280)}
+{$elseif defined(FPC_MCU_ATmega88) or defined(FPC_MCU_ATmega88A) or defined(FPC_MCU_ATmega88P) or defined(FPC_MCU_ATmega88PA)  or defined(FPC_MCU_ATmega88PB)}
+{$elseif defined(FPC_MCU_ATmega8) or defined(FPC_MCU_ATmega8A)}
+
+  xU2X0   = U2X;
+  xRXEN0  = RXEN;
+  xTXEN0  = TXEN;
+  xRXC0   = RXC;
+  xUDRE0  = UDRE;
+  xUCSZ0  = UCSZ;
+  xURSEL0 = URSEL;
+
+  {$define xUBRR0H := UBRRH}
+  {$define xUBRR0L := UBRRL}
+  {$define xUCSR0A := UCSRA}
+  {$define xUCSR0B := UCSRB}
+  {$define xUCSR0C := UCSRC}
+  {$define xUDR0   := UDR}
+
+{$endif}
+
+


### PR DESCRIPTION
Started working in naming conversion for different AVRs MCU's registers and consts. Currently the work is done only for atmega8(A) and atmega328(P/PB).